### PR TITLE
Use folding sidebar

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -18,6 +18,10 @@ site-url = "/pba-book/" # needed for gh-pages, MUST match repo name on github!
 git-repository-url = "https://github.com/Polkadot-Blockchain-Academy/pba-book"
 edit-url-template = "https://github.com/Polkadot-Blockchain-Academy/pba-book/edit/main/{path}"
 
+[output.html.fold]
+enable = true
+level = 0
+
 [output.html.search]
 limit-results = 20
 use-boolean-and = true


### PR DESCRIPTION
We have a _lot_ of pages, this makes the sidebar only display the page highlighted and expand the current chapter, making the sidebar a lot cleaner and easier to reason with.
![image](https://github.com/Polkadot-Blockchain-Academy/pba-book/assets/35669742/cfd66511-b032-4dbf-88b9-be8863f0c417)
